### PR TITLE
feat: ライトモード/ダークモードの切り替え機能を追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,11 +10,5 @@
 .app h1 {
   text-align: center;
   margin-bottom: 1.5rem;
-  color: rgba(255, 255, 255, 0.9);
-}
-
-@media (prefers-color-scheme: light) {
-  .app h1 {
-    color: #333;
-  }
+  color: var(--heading-color);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,15 @@ import { DropZone } from './components/DropZone'
 import { ScriptList } from './components/ScriptList'
 import { FilterPanel } from './components/FilterPanel'
 import { ErrorList } from './components/ErrorList'
+import { ThemeToggle } from './components/ThemeToggle'
+import { useTheme } from './hooks/useTheme'
 import './App.css'
 
 function App() {
   const [files, setFiles] = useState<ScriptFile[]>([])
   const [selectedCharacters, setSelectedCharacters] = useState<Set<string>>(new Set())
   const [errors, setErrors] = useState<FileLoadError[]>([])
+  const { resolvedTheme, toggleTheme } = useTheme()
 
   const handleFilesLoaded = useCallback((newFiles: ScriptFile[]) => {
     setFiles((prev) => [...prev, ...newFiles])
@@ -41,6 +44,7 @@ function App() {
 
   return (
     <div className="app">
+      <ThemeToggle resolvedTheme={resolvedTheme} onToggle={toggleTheme} />
       <h1>Script Viewer</h1>
       <DropZone onFilesLoaded={handleFilesLoaded} onError={handleError} />
       <ErrorList errors={errors} onDismiss={handleDismissErrors} />

--- a/src/components/ThemeToggle.module.css
+++ b/src/components/ThemeToggle.module.css
@@ -1,0 +1,30 @@
+.toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background-color: var(--toggle-bg, #e0e0e0);
+  color: var(--toggle-color, #333);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s, color 0.2s, transform 0.2s;
+  z-index: 1000;
+}
+
+.toggle:hover {
+  transform: scale(1.1);
+}
+
+.toggle:focus {
+  outline: 2px solid var(--toggle-focus, #0066cc);
+  outline-offset: 2px;
+}
+
+.toggle:active {
+  transform: scale(0.95);
+}

--- a/src/components/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ThemeToggle } from './ThemeToggle'
+
+describe('ThemeToggle', () => {
+  it('ダークモード時に太陽アイコンを表示する', () => {
+    const onToggle = vi.fn()
+    render(<ThemeToggle resolvedTheme="dark" onToggle={onToggle} />)
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveAttribute('aria-label', 'ライトモードに切り替え')
+  })
+
+  it('ライトモード時に月アイコンを表示する', () => {
+    const onToggle = vi.fn()
+    render(<ThemeToggle resolvedTheme="light" onToggle={onToggle} />)
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveAttribute('aria-label', 'ダークモードに切り替え')
+  })
+
+  it('クリック時にonToggleが呼ばれる', () => {
+    const onToggle = vi.fn()
+    render(<ThemeToggle resolvedTheme="dark" onToggle={onToggle} />)
+
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,64 @@
+import type { ResolvedTheme } from '../hooks/useTheme'
+import styles from './ThemeToggle.module.css'
+
+interface ThemeToggleProps {
+  resolvedTheme: ResolvedTheme
+  onToggle: () => void
+}
+
+/**
+ * テーマ切り替えボタンコンポーネント
+ * 現在のテーマに応じてアイコンを表示し、クリックで切り替える
+ */
+export function ThemeToggle({ resolvedTheme, onToggle }: ThemeToggleProps) {
+  const isDark = resolvedTheme === 'dark'
+
+  return (
+    <button
+      className={styles.toggle}
+      onClick={onToggle}
+      aria-label={isDark ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
+      title={isDark ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
+    >
+      {isDark ? (
+        // 太陽アイコン（ライトモードへ）
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+      ) : (
+        // 月アイコン（ダークモードへ）
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  )
+}

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTheme } from './useTheme'
+
+describe('useTheme', () => {
+  const localStorageMock = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+    length: 0,
+    key: vi.fn(),
+  }
+
+  const matchMediaMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', localStorageMock)
+    vi.stubGlobal('matchMedia', matchMediaMock)
+    localStorageMock.getItem.mockReturnValue(null)
+    matchMediaMock.mockReturnValue({
+      matches: true, // ダークモード
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('初期状態でsystemテーマを返す', () => {
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe('system')
+  })
+
+  it('localStorageに保存されたテーマを読み込む', () => {
+    localStorageMock.getItem.mockReturnValue('light')
+
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe('light')
+    expect(result.current.resolvedTheme).toBe('light')
+  })
+
+  it('toggleThemeでテーマを切り替える', () => {
+    const { result } = renderHook(() => useTheme())
+
+    // 初期状態はsystem（OS設定に従う、今回はdark）
+    expect(result.current.resolvedTheme).toBe('dark')
+
+    // トグルでlightに
+    act(() => {
+      result.current.toggleTheme()
+    })
+
+    expect(result.current.theme).toBe('light')
+    expect(result.current.resolvedTheme).toBe('light')
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('script-viewer-theme', 'light')
+  })
+
+  it('setThemeでテーマを設定する', () => {
+    const { result } = renderHook(() => useTheme())
+
+    act(() => {
+      result.current.setTheme('dark')
+    })
+
+    expect(result.current.theme).toBe('dark')
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('script-viewer-theme', 'dark')
+  })
+
+  it('HTMLにdata-theme属性を設定する', () => {
+    renderHook(() => useTheme())
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  })
+})

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,78 @@
+import { useState, useEffect, useCallback } from 'react'
+
+// テーマの型定義
+export type Theme = 'light' | 'dark' | 'system'
+
+// 実際に適用されるテーマ（light または dark）
+export type ResolvedTheme = 'light' | 'dark'
+
+const STORAGE_KEY = 'script-viewer-theme'
+
+/**
+ * OSのカラースキーム設定を取得する
+ */
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'dark'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+/**
+ * テーマをHTMLに適用する
+ */
+function applyTheme(resolvedTheme: ResolvedTheme): void {
+  document.documentElement.setAttribute('data-theme', resolvedTheme)
+}
+
+/**
+ * テーマ管理用のカスタムフック
+ * - light/dark/systemの3つのモードをサポート
+ * - localStorageに保存して永続化
+ * - systemモードの場合はOSの設定に従う
+ */
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'system'
+    const saved = localStorage.getItem(STORAGE_KEY) as Theme | null
+    return saved || 'system'
+  })
+
+  // 実際に適用されるテーマを計算
+  const resolvedTheme: ResolvedTheme = theme === 'system' ? getSystemTheme() : theme
+
+  // テーマを設定する関数
+  const setTheme = useCallback((newTheme: Theme) => {
+    setThemeState(newTheme)
+    localStorage.setItem(STORAGE_KEY, newTheme)
+  }, [])
+
+  // テーマを切り替える関数（light <-> dark）
+  const toggleTheme = useCallback(() => {
+    const newTheme: Theme = resolvedTheme === 'dark' ? 'light' : 'dark'
+    setTheme(newTheme)
+  }, [resolvedTheme, setTheme])
+
+  // テーマをHTMLに適用
+  useEffect(() => {
+    applyTheme(resolvedTheme)
+  }, [resolvedTheme])
+
+  // OSのカラースキーム変更を監視（systemモードの場合）
+  useEffect(() => {
+    if (theme !== 'system') return
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleChange = () => {
+      applyTheme(getSystemTheme())
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [theme])
+
+  return {
+    theme,
+    resolvedTheme,
+    setTheme,
+    toggleTheme,
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,14 +3,36 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* ダークモード（デフォルト） */
+  --bg-color: #242424;
+  --text-color: rgba(255, 255, 255, 0.87);
+  --heading-color: rgba(255, 255, 255, 0.9);
+  --toggle-bg: #3a3a3a;
+  --toggle-color: #fff;
+  --toggle-focus: #66b3ff;
+
+  color-scheme: dark;
+  color: var(--text-color);
+  background-color: var(--bg-color);
+}
+
+/* ライトモード */
+:root[data-theme="light"] {
+  --bg-color: #ffffff;
+  --text-color: #213547;
+  --heading-color: #333;
+  --toggle-bg: #e0e0e0;
+  --toggle-color: #333;
+  --toggle-focus: #0066cc;
+
+  color-scheme: light;
+  color: var(--text-color);
+  background-color: var(--bg-color);
 }
 
 * {
@@ -21,11 +43,4 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,41 @@
 import '@testing-library/jest-dom'
+
+// localStorageのモック
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    get length() {
+      return Object.keys(store).length
+    },
+    key: (index: number) => Object.keys(store)[index] || null,
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+})
+
+// matchMediaのモック
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: query === '(prefers-color-scheme: dark)',
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})


### PR DESCRIPTION
## Summary
- テーマ切り替えボタンを画面右上に追加
- ライトモード/ダークモードを手動で切り替え可能に
- 選択したテーマをlocalStorageに保存し、次回訪問時も維持

## 実装内容
- `useTheme` カスタムフック：テーマ状態管理とlocalStorage永続化
- `ThemeToggle` コンポーネント：切り替えボタン（太陽/月アイコン）
- CSS変数によるテーマスタイリング対応

## Test plan
- [ ] テーマ切り替えボタンが表示される
- [ ] クリックでテーマが切り替わる
- [ ] リロードしても選択したテーマが維持される

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)