### PR TITLE
fix: ライトモード時の各コンポーネント配色を修正

### DIFF
--- a/src/components/DropZone.module.css
+++ b/src/components/DropZone.module.css
@@ -4,21 +4,21 @@
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  border: 2px dashed #ccc;
+  border: 2px dashed var(--dropzone-border);
   border-radius: 8px;
-  background-color: #fafafa;
+  background-color: var(--dropzone-bg);
   transition: border-color 0.2s, background-color 0.2s;
 }
 
 .dragOver {
-  border-color: #4a90d9;
-  background-color: #e8f4fd;
+  border-color: var(--dropzone-drag-border);
+  background-color: var(--dropzone-drag-bg);
 }
 
 .dropText {
   margin: 0 0 1rem;
   text-align: center;
-  color: #666;
+  color: var(--dropzone-text);
   line-height: 1.5;
 }
 
@@ -30,7 +30,7 @@
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
   color: #fff;
-  background-color: #4a90d9;
+  background-color: var(--dropzone-btn-bg);
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -38,38 +38,10 @@
 }
 
 .selectButton:hover {
-  background-color: #357abd;
+  background-color: var(--dropzone-btn-hover);
 }
 
 .selectButton:focus {
-  outline: 2px solid #4a90d9;
+  outline: 2px solid var(--dropzone-btn-focus);
   outline-offset: 2px;
-}
-
-@media (prefers-color-scheme: dark) {
-  .dropZone {
-    border-color: #555;
-    background-color: #2d2d2d;
-  }
-
-  .dragOver {
-    border-color: #60a5fa;
-    background-color: #1e3a5f;
-  }
-
-  .dropText {
-    color: #9ca3af;
-  }
-
-  .selectButton {
-    background-color: #3b82f6;
-  }
-
-  .selectButton:hover {
-    background-color: #2563eb;
-  }
-
-  .selectButton:focus {
-    outline-color: #60a5fa;
-  }
 }

--- a/src/components/FileSection.module.css
+++ b/src/components/FileSection.module.css
@@ -1,32 +1,20 @@
 .fileSection {
   margin-bottom: 24px;
   padding: 16px;
-  background: #fff;
+  background: var(--file-section-bg);
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px var(--file-section-shadow);
 }
 
 .fileName {
   font-size: 1.1rem;
-  color: #374151;
+  color: var(--file-section-title);
   margin: 0 0 12px 0;
   padding-bottom: 8px;
-  border-bottom: 2px solid #e5e7eb;
+  border-bottom: 2px solid var(--file-section-border);
 }
 
 .dialogueList {
   display: flex;
   flex-direction: column;
-}
-
-@media (prefers-color-scheme: dark) {
-  .fileSection {
-    background: #2d2d2d;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-  }
-
-  .fileName {
-    color: rgba(255, 255, 255, 0.87);
-    border-bottom-color: #404040;
-  }
 }

--- a/src/components/FilterPanel.module.css
+++ b/src/components/FilterPanel.module.css
@@ -1,7 +1,7 @@
 .filterPanel {
   padding: 1rem;
-  border-bottom: 1px solid #e0e0e0;
-  background-color: #fafafa;
+  border-bottom: 1px solid var(--filter-border);
+  background-color: var(--filter-bg);
 }
 
 .characterList {
@@ -12,27 +12,27 @@
 
 .characterButton {
   padding: 0.5rem 1rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--filter-btn-border);
   border-radius: 4px;
-  background-color: #fff;
-  color: #333;
+  background-color: var(--filter-btn-bg);
+  color: var(--filter-btn-text);
   cursor: pointer;
   font-size: 0.875rem;
   transition: all 0.2s ease;
 }
 
 .characterButton:hover {
-  background-color: #f0f0f0;
+  background-color: var(--filter-btn-hover);
 }
 
 .characterButton.selected {
-  background-color: #1976d2;
+  background-color: var(--filter-btn-selected-bg);
   color: #fff;
-  border-color: #1976d2;
+  border-color: var(--filter-btn-selected-bg);
 }
 
 .characterButton.selected:hover {
-  background-color: #1565c0;
+  background-color: var(--filter-btn-selected-hover);
 }
 
 .filterHeader {
@@ -44,63 +44,22 @@
 
 .filterIndicator {
   font-size: 0.875rem;
-  color: #1976d2;
+  color: var(--filter-indicator);
   font-weight: 500;
 }
 
 .clearButton {
   padding: 0.25rem 0.5rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--filter-btn-border);
   border-radius: 4px;
-  background-color: #fff;
+  background-color: var(--filter-btn-bg);
   cursor: pointer;
   font-size: 0.75rem;
-  color: #666;
+  color: var(--filter-clear-text);
   transition: all 0.2s ease;
 }
 
 .clearButton:hover {
-  background-color: #f0f0f0;
-  color: #333;
-}
-
-@media (prefers-color-scheme: dark) {
-  .filterPanel {
-    border-bottom-color: #404040;
-    background-color: #2d2d2d;
-  }
-
-  .characterButton {
-    border-color: #555;
-    background-color: #3a3a3a;
-    color: #e0e0e0;
-  }
-
-  .characterButton:hover {
-    background-color: #4a4a4a;
-  }
-
-  .characterButton.selected {
-    background-color: #3b82f6;
-    border-color: #3b82f6;
-  }
-
-  .characterButton.selected:hover {
-    background-color: #2563eb;
-  }
-
-  .filterIndicator {
-    color: #60a5fa;
-  }
-
-  .clearButton {
-    border-color: #555;
-    background-color: #3a3a3a;
-    color: #9ca3af;
-  }
-
-  .clearButton:hover {
-    background-color: #4a4a4a;
-    color: #e0e0e0;
-  }
+  background-color: var(--filter-btn-hover);
+  color: var(--filter-btn-text);
 }

--- a/src/components/ScriptItem.module.css
+++ b/src/components/ScriptItem.module.css
@@ -2,7 +2,7 @@
   display: flex;
   gap: 12px;
   padding: 8px 0;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--script-item-border);
 }
 
 .scriptItem:last-child {
@@ -11,26 +11,12 @@
 
 .character {
   font-weight: bold;
-  color: #2563eb;
+  color: var(--script-item-character);
   min-width: 80px;
   flex-shrink: 0;
 }
 
 .text {
-  color: #1f2937;
+  color: var(--script-item-text);
   line-height: 1.5;
-}
-
-@media (prefers-color-scheme: dark) {
-  .scriptItem {
-    border-bottom-color: #404040;
-  }
-
-  .character {
-    color: #60a5fa;
-  }
-
-  .text {
-    color: rgba(255, 255, 255, 0.87);
-  }
 }

--- a/src/components/ScriptList.module.css
+++ b/src/components/ScriptList.module.css
@@ -2,22 +2,12 @@
   flex: 1;
   overflow-y: auto;
   padding: 16px;
-  background: #f9fafb;
+  background: var(--script-list-bg);
 }
 
 .emptyMessage {
   text-align: center;
-  color: #6b7280;
+  color: var(--script-list-empty);
   font-size: 1rem;
   padding: 48px 16px;
-}
-
-@media (prefers-color-scheme: dark) {
-  .scriptList {
-    background: #1a1a1a;
-  }
-
-  .emptyMessage {
-    color: #9ca3af;
-  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,43 @@
   --toggle-color: #fff;
   --toggle-focus: #66b3ff;
 
+  /* DropZone */
+  --dropzone-border: #555;
+  --dropzone-bg: #2d2d2d;
+  --dropzone-text: #9ca3af;
+  --dropzone-drag-border: #60a5fa;
+  --dropzone-drag-bg: #1e3a5f;
+  --dropzone-btn-bg: #3b82f6;
+  --dropzone-btn-hover: #2563eb;
+  --dropzone-btn-focus: #60a5fa;
+
+  /* FilterPanel */
+  --filter-border: #404040;
+  --filter-bg: #2d2d2d;
+  --filter-btn-border: #555;
+  --filter-btn-bg: #3a3a3a;
+  --filter-btn-text: #e0e0e0;
+  --filter-btn-hover: #4a4a4a;
+  --filter-btn-selected-bg: #3b82f6;
+  --filter-btn-selected-hover: #2563eb;
+  --filter-indicator: #60a5fa;
+  --filter-clear-text: #9ca3af;
+
+  /* ScriptList */
+  --script-list-bg: #1a1a1a;
+  --script-list-empty: #9ca3af;
+
+  /* ScriptItem */
+  --script-item-border: #404040;
+  --script-item-character: #60a5fa;
+  --script-item-text: rgba(255, 255, 255, 0.87);
+
+  /* FileSection */
+  --file-section-bg: #2d2d2d;
+  --file-section-shadow: rgba(0, 0, 0, 0.3);
+  --file-section-title: rgba(255, 255, 255, 0.87);
+  --file-section-border: #404040;
+
   color-scheme: dark;
   color: var(--text-color);
   background-color: var(--bg-color);
@@ -29,6 +66,43 @@
   --toggle-bg: #e0e0e0;
   --toggle-color: #333;
   --toggle-focus: #0066cc;
+
+  /* DropZone */
+  --dropzone-border: #ccc;
+  --dropzone-bg: #fafafa;
+  --dropzone-text: #666;
+  --dropzone-drag-border: #4a90d9;
+  --dropzone-drag-bg: #e8f4fd;
+  --dropzone-btn-bg: #4a90d9;
+  --dropzone-btn-hover: #357abd;
+  --dropzone-btn-focus: #4a90d9;
+
+  /* FilterPanel */
+  --filter-border: #e0e0e0;
+  --filter-bg: #fafafa;
+  --filter-btn-border: #ccc;
+  --filter-btn-bg: #fff;
+  --filter-btn-text: #333;
+  --filter-btn-hover: #f0f0f0;
+  --filter-btn-selected-bg: #1976d2;
+  --filter-btn-selected-hover: #1565c0;
+  --filter-indicator: #1976d2;
+  --filter-clear-text: #666;
+
+  /* ScriptList */
+  --script-list-bg: #f9fafb;
+  --script-list-empty: #6b7280;
+
+  /* ScriptItem */
+  --script-item-border: #eee;
+  --script-item-character: #2563eb;
+  --script-item-text: #1f2937;
+
+  /* FileSection */
+  --file-section-bg: #fff;
+  --file-section-shadow: rgba(0, 0, 0, 0.1);
+  --file-section-title: #374151;
+  --file-section-border: #e5e7eb;
 
   color-scheme: light;
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- ライトモード切り替え時に各コンポーネントの配色が正しく反映されるよう修正
- CSS変数を`index.css`に一元化し、`data-theme`属性による切り替えに対応

## 変更内容
- `index.css`: コンポーネント用CSS変数を追加（DropZone, FilterPanel, ScriptList, ScriptItem, FileSection）
- 各コンポーネントCSS: ハードコード色をCSS変数に置換、`prefers-color-scheme`メディアクエリを削除

## Test plan
- [x] ダークモードで各コンポーネントの配色が正しい
- [x] ライトモードに切り替えると各コンポーネントの配色が変わる
- [x] リロードしても選択したテーマが維持される

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)